### PR TITLE
Fix: failing test jobs

### DIFF
--- a/src/scripts/scan.sh
+++ b/src/scripts/scan.sh
@@ -30,11 +30,13 @@ if [[ -n $MAPI_TESTING ]]; then
   echo "MAPI_TESTING parameter was detected.  mapi will now fail if no issues are found."
 fi
 
+# don't fail if the subshell fails (we expect it to if MAPI_TESTING is set)
 set +e
 # redirect output to console as well as capture it to the out var
 exec 5>&1
 out=$(${MAPI} run --url "${API_URL}" "${TARGET}" "${DURATION}" "${API_SPEC}" "${params[@]}" "${run_args[@]}" 2>&1 | tee /dev/fd/5 )
 MAPI_EXIT_CODE=$?
+# restore failure if any command fails
 set -e
 
 echo "mapi exited with code ${MAPI_EXIT_CODE}"

--- a/src/scripts/scan.sh
+++ b/src/scripts/scan.sh
@@ -31,12 +31,13 @@ if [[ -n $MAPI_TESTING ]]; then
 fi
 
 set +e
-out=$(${MAPI} run --url "${API_URL}" "${TARGET}" "${DURATION}" "${API_SPEC}" "${params[@]}" "${run_args[@]}" 2>&1)
+# redirect output to console as well as capture it to the out var
+exec 5>&1
+out=$(${MAPI} run --url "${API_URL}" "${TARGET}" "${DURATION}" "${API_SPEC}" "${params[@]}" "${run_args[@]}" 2>&1 | tee /dev/fd/5 )
 MAPI_EXIT_CODE=$?
 set -e
 
 echo "mapi exited with code ${MAPI_EXIT_CODE}"
-echo "${out}"
 
 if [[ -n $MAPI_TESTING && $MAPI_EXIT_CODE == 1 && "$out" == *"Completed job"* ]]; then
   echo "Expected issues found in test." && exit 0

--- a/src/scripts/scan.sh
+++ b/src/scripts/scan.sh
@@ -26,4 +26,21 @@ mkdir -p "${MAPI_PATH}"
 curl -Lo "${MAPI}" "https://mayhem4api.forallsecure.com/downloads/cli/${MAPI_VERSION}/linux-musl/mapi" \
   && chmod +x "${MAPI}"
 
-${MAPI} run --url "${API_URL}" "${TARGET}" "${DURATION}" "${API_SPEC}" "${params[@]}" "${run_args[@]}"
+if [[ -n $MAPI_TESTING ]]; then
+  echo "MAPI_TESTING parameter was detected.  mapi will now fail if no issues are found."
+fi
+
+set +e
+out=$(${MAPI} run --url "${API_URL}" "${TARGET}" "${DURATION}" "${API_SPEC}" "${params[@]}" "${run_args[@]}" 2>&1)
+MAPI_EXIT_CODE=$?
+set -e
+
+echo "mapi exited with code ${MAPI_EXIT_CODE}"
+echo "${out}"
+
+if [[ -n $MAPI_TESTING && $MAPI_EXIT_CODE == 1 && "$out" == *"Completed job"* ]]; then
+  echo "Expected issues found in test." && exit 0
+else
+  exit $MAPI_EXIT_CODE
+fi
+


### PR DESCRIPTION
Lots of bash here to:

0) set +e to allow the script to continue execution if `mapi` fails (we expect it to now if MAPI_TESTING is set)
1) Add a testing env var that returns error code 0 when tests fail and we are expecting that
2) Log the stdout/stderr of mapi and feed that in to 1) to detect a completed run
3) Write the stdout/stderr to stream 5, which is redirected to the runner's stdout.  This is because we are doing 2) which consumed the mapi output.