### PR TITLE
Add flag to ignore non-zero exit code for mapi CLI

### DIFF
--- a/src/commands/scan.yml
+++ b/src/commands/scan.yml
@@ -35,7 +35,7 @@ parameters:
     type: string
     description: SARIF (Static Analysis Results Interchange Format) report output path. Store the artifact using the `store_artifacts` step.
     default: ""
-  # TODO: rewrite + classify plgin
+  # TODO: rewrite + classify plugin
   # rewrite-plugin:
   #   type: string
   #   description: --experimental-rewrite-plugin option value
@@ -58,6 +58,10 @@ parameters:
     type: string
     description: The path to install the latest binary executable to.
     default: "$HOME/bin"
+  ignore-exit-code:
+    type: boolean
+    description: The `mapi` CLI will exit with with code '1' if any High severity defects are detected in your run. Setting this to true will always exit with code '0', regardless of any discovered defects.
+    default: false
   run-args:
     type: string
     description: A list of additional arguments (separated by '\n') to include in the call to 'mapi run'. Run 'mapi run --help' for a complete list of arguments.
@@ -79,6 +83,7 @@ steps:
         SARIF_REPORT: <<parameters.sarif-report>>
         TARGET: <<parameters.target>>
         ZAP_API_SCAN: <<parameters.zap-api-scan>>
+        IGNORE_EXIT_CODE: <<parameters.ignore-exit-code>>
 
       name: Scan your API with Mayhem for API
       command: <<include(scripts/scan.sh)>>

--- a/src/jobs/scan.yml
+++ b/src/jobs/scan.yml
@@ -54,6 +54,10 @@ parameters:
     type: string
     description: The path to install the latest binary executable to.
     default: "$HOME/bin"
+  ignore-exit-code:
+    type: boolean
+    description: The `mapi` CLI will exit with with code '1' if any High severity defects are detected in your run. Setting this to true will always exit with code '0', regardless of any discovered defects.
+    default: false
   run-args:
     type: string
     description: A list of additional arguments (separated by '\n') to include in the call to 'mapi run'. Run 'mapi run --help' for a complete list of arguments.
@@ -75,6 +79,7 @@ steps:
       sarif-report: <<parameters.sarif-report>>
       target: <<parameters.target>>
       zap-api-scan: <<parameters.zap-api-scan>>
+      ignore-exit-code:  <<parameters.ignore-exit-code>>
   - when:
       condition: <<parameters.html-report>>
       steps:

--- a/src/scripts/scan.sh
+++ b/src/scripts/scan.sh
@@ -43,7 +43,7 @@ echo "mapi exited with code ${MAPI_EXIT_CODE}"
 
 if [[ -n $MAPI_TESTING && $MAPI_EXIT_CODE == 1 && "$out" == *"Completed job"* ]]; then
   echo "Expected issues found in test." && exit 0
-elif [[ $MAPI_EXIT_CODE != 0 && -n $IGNORE_EXIT_CODE ]]; then
+elif [[ $MAPI_EXIT_CODE != 0 && $IGNORE_EXIT_CODE == 1 ]]; then
   echo "Ignoring non-zero exit code returned by mapi." && exit 0
 else
   exit $MAPI_EXIT_CODE

--- a/src/scripts/scan.sh
+++ b/src/scripts/scan.sh
@@ -43,6 +43,8 @@ echo "mapi exited with code ${MAPI_EXIT_CODE}"
 
 if [[ -n $MAPI_TESTING && $MAPI_EXIT_CODE == 1 && "$out" == *"Completed job"* ]]; then
   echo "Expected issues found in test." && exit 0
+elif [[ $MAPI_EXIT_CODE != 0 && -n $IGNORE_EXIT_CODE ]]; then
+  echo "Ignoring non-zero exit code returned by mapi." && exit 0
 else
   exit $MAPI_EXIT_CODE
 fi


### PR DESCRIPTION
* Introduces a new boolean parameter, `ignore-exit-code`.
* The `mapi` CLI will exit with with code '1' if any High severity defects are detected in your run. Setting `ignore-exit-code` to `true` will always exit with code '0', regardless of any discovered defects.
* All discovered defects will still be present in exported reports and the web console. This only impacts the exit code reported by the scan job.